### PR TITLE
jni: interfaces: Add Support For Showing Newer Platform cpubw Status

### DIFF
--- a/app/src/main/jni/interfaces.c
+++ b/app/src/main/jni/interfaces.c
@@ -51,10 +51,13 @@ JNIEXPORT jint JNICALL Java_xzr_perfmon_JniTools_getcpubw
         (JNIEnv *env, jclass jclass1){
     int freq;
 
-    if(readfileint("/sys/class/devfreq/soc:qcom,cpubw/cur_freq",&freq))
-        return UNSUPPORTED;
+    if(!readfileint("/sys/class/devfreq/soc:qcom,cpubw/cur_freq",&freq))
+        return freq;
 
-    return freq;
+    if(!readfileint("/sys/class/devfreq/soc:qcom,cpu-llcc-ddr-bw/cur_freq",&freq))
+        return freq;
+
+    return UNSUPPORTED;
 }
 
 JNIEXPORT jint JNICALL Java_xzr_perfmon_JniTools_getm4m


### PR DESCRIPTION
 * SDM855(sm8150) and newer or same platform soc's cpubw is named as
   soc:qcom,cpu-llcc-ddr-bw
Reported-by: Æsir[@NeonXeon]
Thanks-to:[@zrq8] for building and testing
Test: Build and sucessfully showed cpubw status on OnePlus7Pro(sm8150)

Signed-off-by: Yuhan Zhang <yuhan@rsyhan.me>