### PR TITLE
perfmon: auto modify cpu online file permission(root needed)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "xzr.perfmon"
         minSdkVersion 21
         targetSdkVersion 33
-        versionCode 16
-        versionName "1.7.1"
+        versionCode 17
+        versionName "1.7.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Nov 21 09:36:12 HKT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
perfmon: auto modify cpu online file permission(root needed)
build: Bump version 1.7.1(16)->1.7.2(17)
build: change gradle version to 8.5

`/sys/devices/system/cpu/cpu%d/online` has permissions set to -rw-rw---- (instead of the expected -r--r--r--) in some ROMs, which causes Perfmon+ to incorrectly show the CPU status as offline.
This commit automatically modifies the file permissions (with root access) to fix this issue.